### PR TITLE
Leave Camera files in place

### DIFF
--- a/Resize Images For Google Photos.prf.xml
+++ b/Resize Images For Google Photos.prf.xml
@@ -1,50 +1,22 @@
-<TaskerData sr="" dvi="1" tv="6.1.3-beta">
-	<Profile sr="prof20" ve="2">
-		<cdate>1550431688304</cdate>
-		<edate>1668772177295</edate>
-		<id>20</id>
-		<mid0>35</mid0>
-		<nme>Resize Images For Google Photos</nme>
+<TaskerData sr="" dvi="1" tv="6.3.1-beta">
+	<Task sr="task44">
+		<cdate>1504875429803</cdate>
+		<edate>1707651693228</edate>
+		<id>44</id>
+		<nme>Resize Jpeg Files And leave Originals</nme>
+		<pri>100</pri>
 		<Share sr="Share">
 			<b>false</b>
-			<d>Images and videos uploaded to Google Photos now take up valuable space in your Google account. This profile monitors your DCIM/Camera directory for new images and resizes them so they don't take up as much room.
+			<d>Resize images in the DCIM/Camera directory automatically.
 
-Google Photos isn't really a backup system but it does have very good features such as face recognition and sharing abilities.
-
-Since most of the photos I share there are viewed on a phone I decided I didn't need to upload large photos and let Google resize them to 16MP. Smaller, 1.2MP or 3MP images are just fine for online use.
-
-BACKUP YOUR PHOTOS BEFORE RUNNING THIS THE FIRST TIME.
-
-
-Your original files end up in Download/jpeg/, and the files to upload to Google Photos are placed in DCIM/Resized/.
-
-Resized photos are deleted after 7 days to free up space.</d>
-			<g>Camera,Files</g>
+The original files are left as-is to to prevent problems with the gallery app showing broken images.
+Those images should be moved with a separate task fired from the launcher.
+The resized files are deleted after 1 year.</d>
+			<g>Files,Media</g>
 			<p>true</p>
 			<t></t>
 		</Share>
-		<Event sr="con0" ve="2">
-			<code>222</code>
-			<pri>0</pri>
-			<Str sr="arg0" ve="3">DCIM/Camera/</Str>
-			<Str sr="arg1" ve="3"/>
-		</Event>
-	</Profile>
-	<Task sr="task35">
-		<cdate>1504875429803</cdate>
-		<edate>1668772177295</edate>
-		<id>35</id>
-		<nme>Resize Jpeg Files</nme>
-		<pri>6</pri>
 		<Action sr="act0" ve="7">
-			<code>30</code>
-			<Int sr="arg0" val="0"/>
-			<Int sr="arg1" val="5"/>
-			<Int sr="arg2" val="0"/>
-			<Int sr="arg3" val="0"/>
-			<Int sr="arg4" val="0"/>
-		</Action>
-		<Action sr="act1" ve="7">
 			<code>342</code>
 			<se>false</se>
 			<Int sr="arg0" val="4"/>
@@ -53,124 +25,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Int sr="arg3" val="0"/>
 			<Int sr="arg4" val="1"/>
 		</Action>
-		<Action sr="act10" ve="7">
-			<code>40</code>
-		</Action>
-		<Action sr="act11" ve="7">
-			<code>412</code>
-			<Str sr="arg0" ve="3">Download/WIP</Str>
-			<Str sr="arg1" ve="3">*.jpg</Str>
-			<Int sr="arg2" val="0"/>
-			<Int sr="arg3" val="0"/>
-			<Int sr="arg4" val="0"/>
-			<Str sr="arg5" ve="3">%resizeFiles</Str>
-			<Int sr="arg6" val="1"/>
-		</Action>
-		<Action sr="act12" ve="7">
-			<code>39</code>
-			<Str sr="arg0" ve="3">%filetoresize</Str>
-			<Str sr="arg1" ve="3">%resizeFiles()</Str>
-			<Int sr="arg2" val="1"/>
-		</Action>
-		<Action sr="act13" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">ei</Str>
-			<Str sr="arg1" ve="3">ExifInterface</Str>
-			<Str sr="arg2" ve="3">new
-{ExifInterface} (String)</Str>
-			<Str sr="arg3" ve="3">%filetoresize</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act14" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">%gpslatitude</Str>
-			<Str sr="arg1" ve="3">ei</Str>
-			<Str sr="arg2" ve="3">getAttribute
-{String} (String)</Str>
-			<Str sr="arg3" ve="3">GPSLatitude</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act15" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">%gpslatituderef</Str>
-			<Str sr="arg1" ve="3">ei</Str>
-			<Str sr="arg2" ve="3">getAttribute
-{String} (String)</Str>
-			<Str sr="arg3" ve="3">GPSLatitudeRef</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act16" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">%gpslongitude</Str>
-			<Str sr="arg1" ve="3">ei</Str>
-			<Str sr="arg2" ve="3">getAttribute
-{String} (String)</Str>
-			<Str sr="arg3" ve="3">GPSLongitude</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act17" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">%gpslongituderef</Str>
-			<Str sr="arg1" ve="3">ei</Str>
-			<Str sr="arg2" ve="3">getAttribute
-{String} (String)</Str>
-			<Str sr="arg3" ve="3">GPSLongitudeRef</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act18" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">%gpsaltitude</Str>
-			<Str sr="arg1" ve="3">ei</Str>
-			<Str sr="arg2" ve="3">getAttribute
-{String} (String)</Str>
-			<Str sr="arg3" ve="3">GPSAltitude</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act19" ve="7">
-			<code>664</code>
-			<Str sr="arg0" ve="3">%datetimeoriginal</Str>
-			<Str sr="arg1" ve="3">ei</Str>
-			<Str sr="arg2" ve="3">getAttribute
-{String} (String)</Str>
-			<Str sr="arg3" ve="3">DateTimeOriginal</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Str sr="arg6" ve="3"/>
-			<Str sr="arg7" ve="3"/>
-			<Str sr="arg8" ve="3"/>
-			<Str sr="arg9" ve="3"/>
-		</Action>
-		<Action sr="act2" ve="7">
+		<Action sr="act1" ve="7">
 			<code>409</code>
 			<se>false</se>
 			<Str sr="arg0" ve="3">Download/WIP</Str>
@@ -185,7 +40,184 @@ Resized photos are deleted after 7 days to free up space.</d>
 				</Condition>
 			</ConditionList>
 		</Action>
+		<Action sr="act10" ve="7">
+			<code>38</code>
+		</Action>
+		<Action sr="act11" ve="7">
+			<code>38</code>
+		</Action>
+		<Action sr="act12" ve="7">
+			<code>39</code>
+			<Str sr="arg0" ve="3">%filetoresize</Str>
+			<Str sr="arg1" ve="3">%jpegFilestomove()</Str>
+			<Int sr="arg2" val="1"/>
+		</Action>
+		<Action sr="act13" ve="7">
+			<code>590</code>
+			<Str sr="arg0" ve="3">%filetoresize</Str>
+			<Str sr="arg1" ve="3">/</Str>
+			<Int sr="arg2" val="0"/>
+			<Int sr="arg3" val="0"/>
+		</Action>
+		<Action sr="act14" ve="7">
+			<code>342</code>
+			<se>false</se>
+			<Int sr="arg0" val="4"/>
+			<Str sr="arg1" ve="3">DCIM/Resized/%filetoresize7</Str>
+			<Str sr="arg2" ve="3">%resizedExists</Str>
+			<Int sr="arg3" val="0"/>
+			<Int sr="arg4" val="1"/>
+		</Action>
+		<Action sr="act15" ve="7">
+			<code>37</code>
+			<ConditionList sr="if">
+				<Condition sr="c0" ve="3">
+					<lhs>%resizedExists</lhs>
+					<op>1</op>
+					<rhs>file</rhs>
+				</Condition>
+			</ConditionList>
+		</Action>
+		<Action sr="act16" ve="7">
+			<code>37</code>
+			<ConditionList sr="if">
+				<Condition sr="c0" ve="3">
+					<lhs>%CameraActive</lhs>
+					<op>1</op>
+					<rhs>1</rhs>
+				</Condition>
+			</ConditionList>
+		</Action>
+		<Action sr="act17" ve="7">
+			<code>548</code>
+			<Str sr="arg0" ve="3">New file: %filetoresize7</Str>
+			<Int sr="arg1" val="0"/>
+			<Str sr="arg10" ve="3"/>
+			<Int sr="arg11" val="1"/>
+			<Int sr="arg12" val="0"/>
+			<Str sr="arg13" ve="3"/>
+			<Int sr="arg14" val="0"/>
+			<Str sr="arg15" ve="3"/>
+			<Int sr="arg2" val="0"/>
+			<Str sr="arg3" ve="3"/>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Int sr="arg9" val="1"/>
+		</Action>
+		<Action sr="act18" ve="7">
+			<code>38</code>
+		</Action>
+		<Action sr="act19" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">ei</Str>
+			<Str sr="arg1" ve="3">ExifInterface</Str>
+			<Str sr="arg2" ve="3">new
+{ExifInterface} (String)</Str>
+			<Str sr="arg3" ve="3">%filetoresize</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act2" ve="7">
+			<code>342</code>
+			<se>false</se>
+			<Int sr="arg0" val="4"/>
+			<Str sr="arg1" ve="3">Download/jpeg</Str>
+			<Str sr="arg2" ve="3">%externaljpeg</Str>
+			<Int sr="arg3" val="0"/>
+			<Int sr="arg4" val="1"/>
+		</Action>
 		<Action sr="act20" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">%gpslatitude</Str>
+			<Str sr="arg1" ve="3">ei</Str>
+			<Str sr="arg2" ve="3">getAttribute
+{String} (String)</Str>
+			<Str sr="arg3" ve="3">GPSLatitude</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act21" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">%gpslatituderef</Str>
+			<Str sr="arg1" ve="3">ei</Str>
+			<Str sr="arg2" ve="3">getAttribute
+{String} (String)</Str>
+			<Str sr="arg3" ve="3">GPSLatitudeRef</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act22" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">%gpslongitude</Str>
+			<Str sr="arg1" ve="3">ei</Str>
+			<Str sr="arg2" ve="3">getAttribute
+{String} (String)</Str>
+			<Str sr="arg3" ve="3">GPSLongitude</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act23" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">%gpslongituderef</Str>
+			<Str sr="arg1" ve="3">ei</Str>
+			<Str sr="arg2" ve="3">getAttribute
+{String} (String)</Str>
+			<Str sr="arg3" ve="3">GPSLongitudeRef</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act24" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">%gpsaltitude</Str>
+			<Str sr="arg1" ve="3">ei</Str>
+			<Str sr="arg2" ve="3">getAttribute
+{String} (String)</Str>
+			<Str sr="arg3" ve="3">GPSAltitude</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act25" ve="7">
+			<code>664</code>
+			<Str sr="arg0" ve="3">%datetimeoriginal</Str>
+			<Str sr="arg1" ve="3">ei</Str>
+			<Str sr="arg2" ve="3">getAttribute
+{String} (String)</Str>
+			<Str sr="arg3" ve="3">DateTimeOriginal</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Str sr="arg9" ve="3"/>
+		</Action>
+		<Action sr="act26" ve="7">
 			<code>188</code>
 			<Img sr="arg0" ve="2">
 				<var>%filetoresize</var>
@@ -193,25 +225,40 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Int sr="arg1"/>
 			<Int sr="arg2" val="1"/>
 		</Action>
-		<Action sr="act21" ve="7">
+		<Action sr="act27" ve="7">
 			<code>193</code>
 			<Int sr="arg0" val="1280"/>
 			<Int sr="arg1" val="0"/>
 		</Action>
-		<Action sr="act22" ve="7">
+		<Action sr="act28" ve="7">
 			<code>590</code>
 			<Str sr="arg0" ve="3">%filetoresize</Str>
 			<Str sr="arg1" ve="3">/</Str>
 			<Int sr="arg2" val="0"/>
 			<Int sr="arg3" val="0"/>
 		</Action>
-		<Action sr="act23" ve="7">
+		<Action sr="act29" ve="7">
 			<code>187</code>
 			<Str sr="arg0" ve="3">DCIM/Resized/%filetoresize7</Str>
-			<Int sr="arg1" val="85"/>
+			<Int sr="arg1" val="75"/>
 			<Int sr="arg2" val="1"/>
 		</Action>
-		<Action sr="act24" ve="7">
+		<Action sr="act3" ve="7">
+			<code>409</code>
+			<se>false</se>
+			<Str sr="arg0" ve="3">Download/jpeg</Str>
+			<Int sr="arg1" val="0"/>
+			<Int sr="arg2" val="0"/>
+			<Int sr="arg3" val="1"/>
+			<ConditionList sr="if">
+				<Condition sr="c0" ve="3">
+					<lhs>%externaljpeg</lhs>
+					<op>13</op>
+					<rhs></rhs>
+				</Condition>
+			</ConditionList>
+		</Action>
+		<Action sr="act30" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3">ei</Str>
 			<Str sr="arg1" ve="3">ExifInterface</Str>
@@ -225,7 +272,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act25" ve="7">
+		<Action sr="act31" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -239,7 +286,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act26" ve="7">
+		<Action sr="act32" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -253,7 +300,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act27" ve="7">
+		<Action sr="act33" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -267,7 +314,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act28" ve="7">
+		<Action sr="act34" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -281,7 +328,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act29" ve="7">
+		<Action sr="act35" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -295,16 +342,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act3" ve="7">
-			<code>342</code>
-			<se>false</se>
-			<Int sr="arg0" val="4"/>
-			<Str sr="arg1" ve="3">Download/jpeg</Str>
-			<Str sr="arg2" ve="3">%externaljpeg</Str>
-			<Int sr="arg3" val="0"/>
-			<Int sr="arg4" val="1"/>
-		</Action>
-		<Action sr="act30" ve="7">
+		<Action sr="act36" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -318,7 +356,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act31" ve="7">
+		<Action sr="act37" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -332,7 +370,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act32" ve="7">
+		<Action sr="act38" ve="7">
 			<code>664</code>
 			<Str sr="arg0" ve="3"/>
 			<Str sr="arg1" ve="3">ei</Str>
@@ -346,17 +384,74 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg8" ve="3"/>
 			<Str sr="arg9" ve="3"/>
 		</Action>
-		<Action sr="act33" ve="7">
-			<code>400</code>
-			<Str sr="arg0" ve="3">%filetoresize</Str>
-			<Str sr="arg1" ve="3">Download/jpeg</Str>
-			<Int sr="arg2" val="0"/>
-			<Int sr="arg3" val="1"/>
+		<Action sr="act39" ve="7">
+			<code>459</code>
+			<Str sr="arg0" ve="3">DCIM/Resized/%filetoresize7</Str>
 		</Action>
-		<Action sr="act34" ve="7">
+		<Action sr="act4" ve="7">
+			<code>342</code>
+			<se>false</se>
+			<Int sr="arg0" val="4"/>
+			<Str sr="arg1" ve="3">DCIM/Resized</Str>
+			<Str sr="arg2" ve="3">%externalresized</Str>
+			<Int sr="arg3" val="0"/>
+			<Int sr="arg4" val="1"/>
+		</Action>
+		<Action sr="act40" ve="7">
+			<code>38</code>
+		</Action>
+		<Action sr="act41" ve="7">
 			<code>40</code>
 		</Action>
-		<Action sr="act35" ve="7">
+		<Action sr="act42" ve="7">
+			<code>123</code>
+			<se>false</se>
+			<Str sr="arg0" ve="3">touch /sdcard/DCIM/Camera/.nomedia</Str>
+			<Int sr="arg1" val="0"/>
+			<Int sr="arg2" val="0"/>
+			<Str sr="arg3" ve="3"/>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Int sr="arg6" val="1"/>
+			<Int sr="arg7" val="0"/>
+		</Action>
+		<Action sr="act43" ve="7">
+			<code>123</code>
+			<se>false</se>
+			<Str sr="arg0" ve="3">touch /sdcard/Download/jpeg/.nomedia</Str>
+			<Int sr="arg1" val="0"/>
+			<Int sr="arg2" val="0"/>
+			<Str sr="arg3" ve="3"/>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Int sr="arg6" val="1"/>
+			<Int sr="arg7" val="0"/>
+		</Action>
+		<Action sr="act44" ve="7">
+			<code>123</code>
+			<se>false</se>
+			<Str sr="arg0" ve="3">mv /sdcard/DCIM/Expert Raw/*.jpg /sdcard/Download/jpeg/</Str>
+			<Int sr="arg1" val="0"/>
+			<Int sr="arg2" val="0"/>
+			<Str sr="arg3" ve="3"/>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Int sr="arg6" val="1"/>
+			<Int sr="arg7" val="0"/>
+		</Action>
+		<Action sr="act45" ve="7">
+			<code>123</code>
+			<se>false</se>
+			<Str sr="arg0" ve="3">mv /sdcard/DCIM/Expert Raw/*.dng /sdcard/Download/dng/</Str>
+			<Int sr="arg1" val="0"/>
+			<Int sr="arg2" val="0"/>
+			<Str sr="arg3" ve="3"/>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Int sr="arg6" val="1"/>
+			<Int sr="arg7" val="0"/>
+		</Action>
+		<Action sr="act46" ve="7">
 			<code>412</code>
 			<Str sr="arg0" ve="3">DCIM/Camera</Str>
 			<Str sr="arg1" ve="3">*.mp4</Str>
@@ -366,7 +461,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg5" ve="3">%mp4Filestomove</Str>
 			<Int sr="arg6" val="1"/>
 		</Action>
-		<Action sr="act36" ve="7">
+		<Action sr="act47" ve="7">
 			<code>123</code>
 			<Str sr="arg0" ve="3">mv /sdcard/DCIM/Camera/*.mp4 /sdcard/Download/jpeg/</Str>
 			<Int sr="arg1" val="0"/>
@@ -384,18 +479,7 @@ Resized photos are deleted after 7 days to free up space.</d>
 				</Condition>
 			</ConditionList>
 		</Action>
-		<Action sr="act37" ve="7">
-			<code>123</code>
-			<Str sr="arg0" ve="3">find /sdcard/DCIM/Resized/ -mtime +7 -print -delete</Str>
-			<Int sr="arg1" val="0"/>
-			<Int sr="arg2" val="0"/>
-			<Str sr="arg3" ve="3">%oldfiles</Str>
-			<Str sr="arg4" ve="3"/>
-			<Str sr="arg5" ve="3"/>
-			<Int sr="arg6" val="1"/>
-			<Int sr="arg7" val="0"/>
-		</Action>
-		<Action sr="act38" ve="7">
+		<Action sr="act48" ve="7">
 			<code>123</code>
 			<Str sr="arg0" ve="3">rm -fr /sdcard/DCIM/.thumbnails/*.jpg</Str>
 			<Int sr="arg1" val="0"/>
@@ -406,31 +490,18 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Int sr="arg6" val="1"/>
 			<Int sr="arg7" val="0"/>
 		</Action>
-		<Action sr="act4" ve="7">
-			<code>409</code>
-			<se>false</se>
-			<Str sr="arg0" ve="3">Download/jpeg</Str>
+		<Action sr="act49" ve="7">
+			<code>123</code>
+			<Str sr="arg0" ve="3">find /sdcard/DCIM/Resized/ -mtime +365 -print -delete</Str>
 			<Int sr="arg1" val="0"/>
 			<Int sr="arg2" val="0"/>
-			<Int sr="arg3" val="1"/>
-			<ConditionList sr="if">
-				<Condition sr="c0" ve="3">
-					<lhs>%externaljpeg</lhs>
-					<op>13</op>
-					<rhs></rhs>
-				</Condition>
-			</ConditionList>
+			<Str sr="arg3" ve="3">%oldfiles</Str>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Int sr="arg6" val="1"/>
+			<Int sr="arg7" val="0"/>
 		</Action>
 		<Action sr="act5" ve="7">
-			<code>342</code>
-			<se>false</se>
-			<Int sr="arg0" val="4"/>
-			<Str sr="arg1" ve="3">DCIM/Resized</Str>
-			<Str sr="arg2" ve="3">%externalresized</Str>
-			<Int sr="arg3" val="0"/>
-			<Int sr="arg4" val="1"/>
-		</Action>
-		<Action sr="act6" ve="7">
 			<code>409</code>
 			<se>false</se>
 			<Str sr="arg0" ve="3">DCIM/Resized</Str>
@@ -445,7 +516,26 @@ Resized photos are deleted after 7 days to free up space.</d>
 				</Condition>
 			</ConditionList>
 		</Action>
-		<Action sr="act7" ve="7">
+		<Action sr="act50" ve="7">
+			<code>548</code>
+			<Str sr="arg0" ve="3">Finished Processing Images</Str>
+			<Int sr="arg1" val="0"/>
+			<Str sr="arg10" ve="3"/>
+			<Int sr="arg11" val="1"/>
+			<Int sr="arg12" val="0"/>
+			<Str sr="arg13" ve="3"/>
+			<Int sr="arg14" val="0"/>
+			<Str sr="arg15" ve="3"/>
+			<Int sr="arg2" val="0"/>
+			<Str sr="arg3" ve="3"/>
+			<Str sr="arg4" ve="3"/>
+			<Str sr="arg5" ve="3"/>
+			<Str sr="arg6" ve="3"/>
+			<Str sr="arg7" ve="3"/>
+			<Str sr="arg8" ve="3"/>
+			<Int sr="arg9" val="1"/>
+		</Action>
+		<Action sr="act6" ve="7">
 			<code>412</code>
 			<Str sr="arg0" ve="3">DCIM/Camera</Str>
 			<Str sr="arg1" ve="3">*.jpg</Str>
@@ -455,19 +545,36 @@ Resized photos are deleted after 7 days to free up space.</d>
 			<Str sr="arg5" ve="3">%jpegFilestomove</Str>
 			<Int sr="arg6" val="1"/>
 		</Action>
+		<Action sr="act7" ve="7">
+			<code>37</code>
+			<ConditionList sr="if">
+				<Condition sr="c0" ve="3">
+					<lhs>%jpegFilestomove(#)</lhs>
+					<op>7</op>
+					<rhs>0</rhs>
+				</Condition>
+			</ConditionList>
+		</Action>
 		<Action sr="act8" ve="7">
-			<code>39</code>
-			<coll>false</coll>
-			<Str sr="arg0" ve="3">%files</Str>
-			<Str sr="arg1" ve="3">%jpegFilestomove()</Str>
-			<Int sr="arg2" val="0"/>
+			<code>37</code>
+			<ConditionList sr="if">
+				<Condition sr="c0" ve="3">
+					<lhs>%CameraActive</lhs>
+					<op>0</op>
+					<rhs>1</rhs>
+				</Condition>
+			</ConditionList>
 		</Action>
 		<Action sr="act9" ve="7">
-			<code>400</code>
-			<Str sr="arg0" ve="3">%files</Str>
-			<Str sr="arg1" ve="3">Download/WIP</Str>
+			<code>30</code>
+			<Int sr="arg0" val="0"/>
+			<Int sr="arg1" val="3"/>
 			<Int sr="arg2" val="0"/>
-			<Int sr="arg3" val="1"/>
+			<Int sr="arg3" val="0"/>
+			<Int sr="arg4" val="0"/>
 		</Action>
+		<Img sr="icn" ve="2">
+			<nme>mw_action_camera_enhance</nme>
+		</Img>
 	</Task>
 </TaskerData>


### PR DESCRIPTION
This is an update from taskernet [here](https://taskernet.com/shares/?user=AS35m8lp%2FKkm%2B8UbZhHqE5Y4xnByvXtx0JMDOCGm0w6uyiTpJO0jakx9uvUppJnAx%2BE%3D&id=Task%3AResize+Jpeg+Files+And+leave+Originals#). The name of the Task has changed to "Resize Jpeg Files And leave Originals".

The files in DCIM/Camera aren't moved to a WIP directory any more. The script checks if the file is in the Resized directory, and if it's not, it creates a resized version.
It now uses the Media Scanner so Android knows about the new file immediately.